### PR TITLE
Added prebuild's dependency on installGitHook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,3 +39,5 @@ task installGitHook(type: Copy) {
     into { new File(rootProject.rootDir, '.git/hooks') }
     fileMode 0777
 }
+
+tasks.getByPath(':ui:preBuild').dependsOn installGitHook


### PR DESCRIPTION
This way whenever a new clone is made and ui module is built for first time the installGitHook task runs and the script is copied into the hooks

Fixes: #3 